### PR TITLE
Documentation improvements for running tests with labels (#275)

### DIFF
--- a/INSTALL.md
+++ b/INSTALL.md
@@ -180,7 +180,7 @@ However, you can manually launch this program through the command line and chang
 Running ctest might take a while so, you may want to [request a computational node](https://docs.computecanada.ca/wiki/Running_jobs) before running.
 Note that you want to request at least as many processes as MPIMAX.
 ~~~~
-ctest -LE EXTRA-LONG -LE EXPECTED_FAILURE
+ctest -LE EXTRA-LONG
 ~~~~
 The  `-LE EXTRA-LONG` flag will disable all tests that will take over an hour and should only be removed when wanting to
 run tests that will take over an hour. The `-LE` flag will disable all tests that are expected to fail. All tests also have labels and can be used with the `-L` flag. For example,

--- a/README.md
+++ b/README.md
@@ -112,8 +112,12 @@ ROOT$ ctest -N (List the tests that would be run but not actually run them)
 ROOT$ ctest -R <regex> (Run tests matching regular expression)
 ROOT$ ctest -E <regex> (Exclude tests matching regular expression)
 ROOT$ ctest -V (Enable verbose output from tests)
+ROOT$ ctest -L <label> (Run tests matching label)
+ROOT$ ctest -LE <label> (Exclude tests matching label)
 ```
 Note that running `ctest` in `Debug` will take forever since some integration tests fully solve nonlinear problems with multiple orders and multiple meshes. It is suggested to perform `ctest` in `Release` mode, and only use `Debug` mode for debugging purposes.
+
+More detail about running tests using labels can be found [here](tests/CTEST_LABELS.md).
 
 ## Debugging
 

--- a/doc/install_ubuntu2004_VM.sh
+++ b/doc/install_ubuntu2004_VM.sh
@@ -183,5 +183,5 @@ mkdir -p Codes
         # 	however, it does not work well on Ubuntu with OpenMPI. Works well with Fedora
         cmake ../ -DCMAKE_BUILD_TYPE=Release -DMPIMAX=4 -DUSE_LD_GOLD=OFF ;\
         make -j4 ;\
-        ctest ;\
+        ctest -LE EXTRA-LONG ;\
 )


### PR DESCRIPTION
A few small changes to make it easier for users to find information about using labels with `ctest`.